### PR TITLE
Better name for JA3 nginx variables

### DIFF
--- a/src/ngx_http_ssl_ja3_module.c
+++ b/src/ngx_http_ssl_ja3_module.c
@@ -139,12 +139,12 @@ ngx_http_ssl_ja3(ngx_http_request_t *r,
 
 static ngx_http_variable_t  ngx_http_ssl_ja3_variables_list[] = {
 
-    {   ngx_string("http_ssl_ja3_hash"),
+    {   ngx_string("tls_ja3_hash"),
         NULL,
         ngx_http_ssl_ja3_hash,
         0, 0, 0
     },
-    {   ngx_string("http_ssl_ja3"),
+    {   ngx_string("tls_ja3"),
         NULL,
         ngx_http_ssl_ja3,
         0, 0, 0

--- a/src/ngx_stream_ssl_ja3_preread_module.c
+++ b/src/ngx_stream_ssl_ja3_preread_module.c
@@ -137,12 +137,12 @@ ngx_stream_ssl_ja3(ngx_stream_session_t *s,
 
 static ngx_stream_variable_t  ngx_stream_ssl_ja3_variables_list[] = {
 
-    {   ngx_string("stream_ssl_ja3_hash"),
+    {   ngx_string("tls_ja3_hash"),
         NULL,
         ngx_stream_ssl_ja3_hash,
         0, 0, 0
     },
-    {   ngx_string("stream_ssl_ja3"),
+    {   ngx_string("tls_ja3"),
         NULL,
         ngx_stream_ssl_ja3,
         0, 0, 0


### PR DESCRIPTION
In nginx, variables starting with `http` represent HTTP requests header.
    
Rename the JA3 variables removing the `http` and `stream prefixes`, to make it obvious they are not coming from an HTTP request and they belong tp the TLS handshake.