### PR TITLE
Update nginx-ja3-1.20.2.patch

### DIFF
--- a/patches/nginx-ja3-1.20.2.patch
+++ b/patches/nginx-ja3-1.20.2.patch
@@ -1,8 +1,7 @@
-diff --git a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
-index b64285ab..9427249c 100644
---- a/src/event/ngx_event_openssl.c
-+++ b/src/event/ngx_event_openssl.c
-@@ -1742,6 +1742,108 @@ ngx_ssl_set_session(ngx_connection_t *c, ngx_ssl_session_t *session)
+diff -ur nginx-1.25.2/src/event/ngx_event_openssl.c nginx-1.25.2-patched/src/event/ngx_event_openssl.c
+--- nginx-1.25.2/src/event/ngx_event_openssl.c	2023-10-09 17:55:51.284779025 +0000
++++ nginx-1.25.2-patched/src/event/ngx_event_openssl.c	2023-10-09 17:59:11.559503343 +0000
+@@ -1793,6 +1793,112 @@
      return NGX_OK;
  }
  
@@ -87,6 +86,10 @@ index b64285ab..9427249c 100644
 +        return 1;
 +    }
 +
++    if (c->destroyed == 1) {
++    	return 1;
++    }
++
 +    c->ssl->extensions_size = 0;
 +    c->ssl->extensions = NULL;
 +    got_extensions = SSL_client_hello_get1_extensions_present(s,
@@ -111,7 +114,7 @@ index b64285ab..9427249c 100644
  
  ngx_int_t
  ngx_ssl_handshake(ngx_connection_t *c)
-@@ -1762,6 +1863,10 @@ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1813,6 +1919,10 @@
  
      ngx_ssl_clear_error(c->log);
  
@@ -122,7 +125,7 @@ index b64285ab..9427249c 100644
      n = SSL_do_handshake(c->ssl->connection);
  
      ngx_log_debug1(NGX_LOG_DEBUG_EVENT, c->log, 0, "SSL_do_handshake: %d", n);
-@@ -1780,6 +1885,12 @@ ngx_ssl_handshake(ngx_connection_t *c)
+@@ -1831,6 +1941,12 @@
          ngx_ssl_handshake_log(c);
  #endif
  
@@ -135,11 +138,10 @@ index b64285ab..9427249c 100644
          c->recv = ngx_ssl_recv;
          c->send = ngx_ssl_write;
          c->recv_chain = ngx_ssl_recv_chain;
-diff --git a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
-index 7fe45351..453cfb02 100644
---- a/src/event/ngx_event_openssl.h
-+++ b/src/event/ngx_event_openssl.h
-@@ -132,6 +132,19 @@ struct ngx_ssl_connection_s {
+diff -ur nginx-1.25.2/src/event/ngx_event_openssl.h nginx-1.25.2-patched/src/event/ngx_event_openssl.h
+--- nginx-1.25.2/src/event/ngx_event_openssl.h	2023-10-09 17:55:43.028666728 +0000
++++ nginx-1.25.2-patched/src/event/ngx_event_openssl.h	2023-10-09 17:57:17.877956875 +0000
+@@ -141,6 +141,19 @@
      ngx_ssl_dyn_rec_t           dyn_rec;
      ngx_msec_t                  dyn_rec_last_write;
      ngx_uint_t                  dyn_rec_records_sent;
@@ -157,5 +159,4 @@ index 7fe45351..453cfb02 100644
 +    #endif
 +    /* ----- JA3 HACK END -------------------------------------------------------*/
  };
- 
- 
+


### PR DESCRIPTION
ja3 module was segfaulting. It could rarely get in the callback but the connection is already being destroyed, so skip those cases.